### PR TITLE
Add optional SSL verification disable for self-signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,34 @@ Environment variables:
 - `JIRA_MCP_TOKEN` (required): API authentication token
 - `JIRA_MCP_CACHE_TTL` (optional, default: 3600): Schema cache TTL in seconds
 - `JIRA_MCP_TIMEOUT` (optional, default: 30): HTTP request timeout in seconds
+- `JIRA_MCP_VERIFY_SSL` (optional, default: true): Verify SSL certificates
+
+### SSL Certificate Verification
+
+By default, the server verifies SSL certificates. For testing with self-signed certificates, you can disable SSL verification:
+
+```bash
+export JIRA_MCP_VERIFY_SSL="false"
+```
+
+Or in your AI assistant configuration:
+
+```json
+{
+  "mcpServers": {
+    "jira": {
+      "command": "fastmcp-jira-server",
+      "env": {
+        "JIRA_MCP_URL": "https://jira.yourcompany.com",
+        "JIRA_MCP_TOKEN": "your-api-token-here",
+        "JIRA_MCP_VERIFY_SSL": "false"
+      }
+    }
+  }
+}
+```
+
+**⚠️ Security Warning**: Disabling SSL verification should only be used for testing with self-signed certificates or internal development. Never use this in production environments as it makes your connection vulnerable to man-in-the-middle attacks.
 
 ## Development
 

--- a/src/jira_mcp_server/config.py
+++ b/src/jira_mcp_server/config.py
@@ -14,12 +14,14 @@ class JiraConfig(BaseSettings):
     Optional environment variables:
     - JIRA_MCP_CACHE_TTL: Schema cache TTL in seconds (default: 3600)
     - JIRA_MCP_TIMEOUT: HTTP request timeout in seconds (default: 30)
+    - JIRA_MCP_VERIFY_SSL: Verify SSL certificates (default: true, set to false for self-signed certs)
     """
 
     url: str = Field(..., description="Jira instance URL")
     token: str = Field(..., description="API authentication token")
     cache_ttl: int = Field(default=3600, description="Schema cache TTL in seconds", gt=0)
     timeout: int = Field(default=30, description="HTTP request timeout in seconds", gt=0)
+    verify_ssl: bool = Field(default=True, description="Verify SSL certificates (disable for self-signed certs)")
 
     model_config = SettingsConfigDict(
         env_prefix="JIRA_MCP_",

--- a/src/jira_mcp_server/jira_client.py
+++ b/src/jira_mcp_server/jira_client.py
@@ -22,6 +22,7 @@ class JiraClient:
         self.base_url = config.url
         self.timeout = config.timeout
         self._token = config.token
+        self.verify_ssl = config.verify_ssl
 
     def _get_headers(self) -> Dict[str, str]:
         """Get HTTP headers with authentication.
@@ -107,7 +108,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/serverInfo"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -142,7 +143,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue/{issue_key}"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -170,7 +171,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.post(url, headers=self._get_headers(), json=issue_data)
 
                 if response.status_code not in (200, 201):
@@ -194,7 +195,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue/{issue_key}"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.put(url, headers=self._get_headers(), json=update_data)
 
                 if response.status_code not in (200, 204):
@@ -224,7 +225,7 @@ class JiraClient:
         }
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers(), params=params)
 
                 if response.status_code != 200:
@@ -264,7 +265,7 @@ class JiraClient:
         data = {"jql": jql, "maxResults": max_results, "startAt": start_at}
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.post(url, headers=self._get_headers(), json=data)
 
                 if response.status_code != 200:
@@ -298,7 +299,7 @@ class JiraClient:
             data["description"] = description
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.post(url, headers=self._get_headers(), json=data)
 
                 if response.status_code not in (200, 201):
@@ -321,7 +322,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/filter/my"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -347,7 +348,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/filter/{filter_id}"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -396,7 +397,7 @@ class JiraClient:
             raise ValueError("At least one field must be provided to update")
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.put(url, headers=self._get_headers(), json=data)
 
                 if response.status_code != 200:
@@ -419,7 +420,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/filter/{filter_id}"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.delete(url, headers=self._get_headers())
 
                 if response.status_code != 204:
@@ -443,7 +444,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue/{issue_key}/transitions"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -471,7 +472,7 @@ class JiraClient:
             data["fields"] = fields
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.post(url, headers=self._get_headers(), json=data)
 
                 if response.status_code != 204:
@@ -497,7 +498,7 @@ class JiraClient:
         data = {"body": body}
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.post(url, headers=self._get_headers(), json=data)
 
                 if response.status_code not in (200, 201):
@@ -523,7 +524,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue/{issue_key}/comment"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.get(url, headers=self._get_headers())
 
                 if response.status_code != 200:
@@ -552,7 +553,7 @@ class JiraClient:
         data = {"body": body}
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.put(url, headers=self._get_headers(), json=data)
 
                 if response.status_code != 200:
@@ -576,7 +577,7 @@ class JiraClient:
         url = f"{self.base_url}/rest/api/2/issue/{issue_key}/comment/{comment_id}"
 
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=self.timeout, verify=self.verify_ssl) as client:
                 response = client.delete(url, headers=self._get_headers())
 
                 if response.status_code != 204:

--- a/src/jira_mcp_server/server.py
+++ b/src/jira_mcp_server/server.py
@@ -641,6 +641,12 @@ def main() -> None:
         print(f"Jira URL: {config.url}")
         print(f"Cache TTL: {config.cache_ttl}s")
         print(f"Timeout: {config.timeout}s")
+        print(f"SSL Verification: {'Enabled' if config.verify_ssl else 'DISABLED (Testing Only)'}")
+        if not config.verify_ssl:
+            print()
+            print("⚠️  WARNING: SSL certificate verification is DISABLED!")
+            print("   This should only be used for testing with self-signed certificates.")
+            print("   DO NOT use this in production environments.")
         print()
         print("Server ready! Use MCP client to interact with Jira.")
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,6 +17,7 @@ class TestJiraConfig:
         assert config.token == "test-token-123"
         assert config.cache_ttl == 3600  # Default
         assert config.timeout == 30  # Default
+        assert config.verify_ssl is True  # Default
 
     def test_config_uses_custom_values(self) -> None:
         """Test that config accepts custom TTL and timeout values."""
@@ -84,3 +85,15 @@ class TestJiraConfig:
 
         assert config.url == "https://jira.example.com"
         assert not config.url.endswith("/")
+
+    def test_config_verify_ssl_default_true(self) -> None:
+        """Test that SSL verification is enabled by default."""
+        config = JiraConfig(url="https://jira.example.com", token="test-token-123")
+
+        assert config.verify_ssl is True
+
+    def test_config_verify_ssl_can_be_disabled(self) -> None:
+        """Test that SSL verification can be disabled for testing."""
+        config = JiraConfig(url="https://jira.example.com", token="test-token-123", verify_ssl=False)
+
+        assert config.verify_ssl is False

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -66,12 +66,49 @@ class TestMain:
         mock_config.url = "https://jira.test.com"
         mock_config.cache_ttl = 3600
         mock_config.timeout = 30
+        mock_config.verify_ssl = True
         mock_config_class.return_value = mock_config
 
         server.main()
 
         mock_initialize.assert_called_once_with(mock_config)
         mock_mcp_run.assert_called_once()
+
+    @patch("jira_mcp_server.server.mcp.run")
+    @patch("jira_mcp_server.server.initialize_issue_tools")
+    @patch("jira_mcp_server.server.initialize_search_tools")
+    @patch("jira_mcp_server.server.initialize_filter_tools")
+    @patch("jira_mcp_server.server.initialize_workflow_tools")
+    @patch("jira_mcp_server.server.initialize_comment_tools")
+    @patch("jira_mcp_server.server.JiraClient")
+    @patch("jira_mcp_server.server.JiraConfig")
+    @patch("builtins.print")
+    def test_main_with_ssl_disabled_shows_warning(
+        self,
+        mock_print: Mock,
+        mock_config_class: Mock,
+        mock_client_class: Mock,
+        mock_init_comment: Mock,
+        mock_init_workflow: Mock,
+        mock_init_filter: Mock,
+        mock_init_search: Mock,
+        mock_init_issue: Mock,
+        mock_mcp_run: Mock,
+    ) -> None:
+        """Test that SSL warning is displayed when verification is disabled."""
+        mock_config = Mock()
+        mock_config.url = "https://jira.test.com"
+        mock_config.cache_ttl = 3600
+        mock_config.timeout = 30
+        mock_config.verify_ssl = False
+        mock_config_class.return_value = mock_config
+
+        server.main()
+
+        # Verify warning message was printed
+        warning_calls = [str(call) for call in mock_print.call_args_list]
+        warning_found = any("WARNING" in str(call) and "SSL" in str(call) for call in warning_calls)
+        assert warning_found, "Expected SSL warning message to be printed"
 
     @patch("jira_mcp_server.server.JiraConfig")
     @patch("builtins.print")


### PR DESCRIPTION
## Summary

Adds optional SSL verification disable feature for testing with self-signed certificates.

Closes #13

## Changes

- Added `JIRA_MCP_VERIFY_SSL` environment variable (defaults to `true`)
- Updated `JiraConfig` with `verify_ssl` boolean field  
- Modified `JiraClient` to pass `verify` parameter to all httpx.Client calls
- Added security warning when SSL verification is disabled at startup
- Updated README with configuration documentation and security warning

## Security

- **Defaults to `true`**: SSL verification enabled by default for production safety
- **Warning displayed**: Prominent warning shown when disabled
- **Documentation**: Clear guidance that this is for testing/development only

## Testing

- ✅ 341 tests passing with 100% coverage
- ✅ Added `test_config_verify_ssl_default_true`
- ✅ Added `test_config_verify_ssl_can_be_disabled`
- ✅ Added `test_main_with_ssl_disabled_shows_warning`

## Usage

```json
{
  "mcpServers": {
    "jira": {
      "command": "fastmcp-jira-server",
      "env": {
        "JIRA_MCP_URL": "https://jira.yourcompany.com",
        "JIRA_MCP_TOKEN": "your-api-token-here",
        "JIRA_MCP_VERIFY_SSL": "false"
      }
    }
  }
}
```

**⚠️ Security Warning**: Disabling SSL verification should only be used for testing with self-signed certificates. Never use this in production.